### PR TITLE
Link replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## Pygmalion Docs
+## Pygmalion Documentation
 
-**You can find the website at [docs.alpindale.dev](https://docs.alpindale.dev)**
+**You can find the website at [docs.pygmalion.chat](http://docs.pygmalion.chat)**
 
 Running the docs on your PC locally:
 
@@ -32,4 +32,4 @@ npx retypeapp watch
 
 ***
 
-Please regularly update with `git pull`. This is still a WIP so updates are expected at an hourly basis.
+Please regularly update with `git pull`. This is still a WIP so updates are expected at a daily basis.

--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ npx retypeapp watch
 
 ***
 
-Please regularly update with `git pull`. This is still a WIP so updates are expected at a daily basis.
+Please regularly update with `git pull`. This is still a WIP so updates are often expected.

--- a/src/Cloud Installation/_KoboldAI.md
+++ b/src/Cloud Installation/_KoboldAI.md
@@ -27,6 +27,6 @@ You might be warned that the notebook is not authored by Google - you can ignore
 ![](/static/kobold-cloud2.PNG)
 
 !!!success You're done! 
-You can start using Pygmalion if you clicked on the second link. If you want to use it with Tavern, please refer to the [SillyTavern](https://docs.alpindale.dev/pygmalion-extras/sillytavern/) guide included here or the [Agnaistic Guide](https://docs.alpindale.dev/pygmalion-extras/agnaistic/) included here.
+You can start using Pygmalion if you clicked on the second link. If you want to use it with Tavern, please refer to the [SillyTavern](https://docs.pygmalion.chat/pygmalion-extras/sillytavern/) guide included here or the [Agnaistic Guide](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/) included here.
 !!!
 

--- a/src/Cloud Installation/_kobold.md
+++ b/src/Cloud Installation/_kobold.md
@@ -21,6 +21,6 @@ You might be warned that the notebook is not authored by Google - you can ignore
 ![](/static/kobold-cloud2.PNG)
 
 !!!success You're done! 
-You can start using Pygmalion if you clicked on the second link. If you want to use it with Tavern, please refer to the TavernAI guide included here  or the [Agnaistic Guide](https://docs.alpindale.dev/pygmalion-extras/agnaistic/) included here.
+You can start using Pygmalion if you clicked on the second link. If you want to use it with Tavern, please refer to the TavernAI guide included here  or the [Agnaistic Guide](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/) included here.
 !!!
 

--- a/src/Cloud Installation/horde.md
+++ b/src/Cloud Installation/horde.md
@@ -15,12 +15,12 @@ This key will be permanently yours. It's as important as a password, so never gi
 
 ## How to use Pygmalion on the Horde
 
-Pygmalion is a popular model, so you'll always find at least a few workers (people hosting the model for the public) on the Horde. You can either use the official [Kobold Horde website](https://lite.koboldai.net), but it's recommended to use a UI such as [SillyTavern](https://docs.alpindale.dev/pygmalion-extras/sillytavern/) or [Agnaistic](https://docs.alpindale.dev/pygmalion-extras/agnaistic/). 
+Pygmalion is a popular model, so you'll always find at least a few workers (people hosting the model for the public) on the Horde. You can either use the official [Kobold Horde website](https://lite.koboldai.net), but it's recommended to use a UI such as [SillyTavern](https://docs.pygmalion.chat/pygmalion-extras/sillytavern/) or [Agnaistic](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/). 
 
 
 ### SillyTavern
 
-Follow the installation instructions [here](https://docs.alpindale.dev/pygmalion-extras/sillytavern/). Once you launch SillyTavern, click on the **red plug** icon, choose **KoboldAI** from the "API" drop-down menu, check the "**Use Horde**" option, paste your Horde API Key in the "**API Key**" input box, and then select your desired model from the models list. 
+Follow the installation instructions [here](https://docs.pygmalion.chat/pygmalion-extras/sillytavern/). Once you launch SillyTavern, click on the **red plug** icon, choose **KoboldAI** from the "API" drop-down menu, check the "**Use Horde**" option, paste your Horde API Key in the "**API Key**" input box, and then select your desired model from the models list. 
 ![](../static/horde-tavern.png)
 You're done! You can now start chatting. Import a character by opening "Character Management", clicking on the "Import Character from File" button, and selecting your character. Character cards can be acquired from the [Discord](https://discord.com/invite/pygmalionai) or the unofficial [booru](https://booru.plus/+pygmalion).
 
@@ -45,7 +45,7 @@ Alternatively, you can ask other users to transfer kudos for you.
 
 ## How to host Pygmalion on the Horde
 
-You'll need to run Pygmalion with [KoboldAI](https://docs.alpindale.dev/local-installation-(gpu)/kobold/). The [4bit KoboldAI](https://docs.alpindale.dev/local-installation-(gpu)/koboldai4bit/) will also work fine. Make sure you're in the New UI (you can access it by adding `/new_ui` at the end of your Kobold URL or clicking on the `Try New UI` button). Load the model you want to host, head over to "Settings" and set your Horde Worker's name (arbitrary name) and the Horde API Key (this will be the API key you get when registering). 
+You'll need to run Pygmalion with [KoboldAI](https://docs.pygmalion.chat/local-installation-(gpu)/kobold/). The [4bit KoboldAI](https://docs.pygmalion.chat/local-installation-(gpu)/koboldai4bit/) will also work fine. Make sure you're in the New UI (you can access it by adding `/new_ui` at the end of your Kobold URL or clicking on the `Try New UI` button). Load the model you want to host, head over to "Settings" and set your Horde Worker's name (arbitrary name) and the Horde API Key (this will be the API key you get when registering). 
 ![](../static/horde-kobold1.png)
 
 Then head over to home, and toggle the "Share with Horde" switch. 

--- a/src/Cloud Installation/vast.md
+++ b/src/Cloud Installation/vast.md
@@ -43,7 +43,7 @@ Once it's finished loading, click on the logs button to view your remote url:
 This process can take up to 3 minutes, so it's advised to close and re-open the logs window until the url shows up at the end.
 !!!
 
-Now, paste the URL in a browser tab and you're ready to use Kobold! You can load Pygmalion 6B by clicking on `Models` on the top-left corner of the screen, selecting the `Chat models` section, selecting Pygmalion 6B, and then clicking on `Load`. This will download the model for you. Keep in mind that the download is 16GB, but if you've chosen a machine with a fast download speed, it shouldn't take long. The steps should be familiar for users running locally, so you can also refer to the [Local installation guide for Kobold](https://docs.alpindale.dev/local-installation-(gpu)/kobold/).
+Now, paste the URL in a browser tab and you're ready to use Kobold! You can load Pygmalion 6B by clicking on `Models` on the top-left corner of the screen, selecting the `Chat models` section, selecting Pygmalion 6B, and then clicking on `Load`. This will download the model for you. Keep in mind that the download is 16GB, but if you've chosen a machine with a fast download speed, it shouldn't take long. The steps should be familiar for users running locally, so you can also refer to the [Local installation guide for Kobold](https://docs.pygmalion.chat/local-installation-(gpu)/kobold/).
 
 !!!success You're done!
 You're now ready to use PygmalionAI! Make sure you delete (or stop, if you don't mind paying for the hourly storage charges of 0.8 cents/hr) your instance so you won't be billed when you're not using your instance. If you delete the instance, you'll have to go through the process of setting it up again, but stopping and resuming should pick up from where you left off. 
@@ -51,8 +51,8 @@ You're now ready to use PygmalionAI! Make sure you delete (or stop, if you don't
 
 ## Connecting your instance to TavernAI
 
-You can easily use TavernAI along with Kobold. Follow the instructions in the [Tavern guide](https://docs.alpindale.dev/pygmalion-extras/sillytavern/) but instead of inputting `localhost:5000/api`, use your `trycloudflare.com` link. Assuming your URL was `https://pieces-strictly-transparency-luther.trycloudflare.com/new_ui`, you would paste it as `https://pieces-strictly-transparency-luther.trycloudflare.com/api` inside Tavern. Note that the `new_ui` part is removed and replaced with `/api`. 
+You can easily use TavernAI along with Kobold. Follow the instructions in the [Tavern guide](https://docs.pygmalion.chat/pygmalion-extras/sillytavern/) but instead of inputting `localhost:5000/api`, use your `trycloudflare.com` link. Assuming your URL was `https://pieces-strictly-transparency-luther.trycloudflare.com/new_ui`, you would paste it as `https://pieces-strictly-transparency-luther.trycloudflare.com/api` inside Tavern. Note that the `new_ui` part is removed and replaced with `/api`. 
 
 ## Connecting your instance to Agnaistic
 
-You can easily use Agnaistic along with Kobold. Follow the instructions in the [Agnaistic Guide](https://docs.alpindale.dev/pygmalion-extras/agnaistic/) but instead of inputting `localhost:5000/`, use your `trycloudflare.com` link. Assuming your URL was `https://pieces-strictly-transparency-luther.trycloudflare.com/new_ui`, you would paste it as `https://pieces-strictly-transparency-luther.trycloudflare.com` inside Agnaistic. Note that the `new_ui` part is removed. 
+You can easily use Agnaistic along with Kobold. Follow the instructions in the [Agnaistic Guide](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/) but instead of inputting `localhost:5000/`, use your `trycloudflare.com` link. Assuming your URL was `https://pieces-strictly-transparency-luther.trycloudflare.com/new_ui`, you would paste it as `https://pieces-strictly-transparency-luther.trycloudflare.com` inside Agnaistic. Note that the `new_ui` part is removed. 

--- a/src/FAQ.md
+++ b/src/FAQ.md
@@ -62,9 +62,9 @@ Even if people tend to use it that way, softprompt are not made to add context, 
 It's up to you, every UI tends to add the same features others as well as try to be compatible with characters from other UIs as well.
 If you want to focus on story generation, we recommend using KoboldAI. For chat purposes, TavernAI has the best user interface, followed by Oobabooga. There are other TavernAI alternatives (e.g. miku.gg), but it's up to you in the end. Please refer to their respective pages for a preview of the UI.
 
-[!button text="KoboldAI"](https://docs.alpindale.dev/local-installation-(gpu)/kobold) - 
-[!button text="Text-Gen-WebUI"](https://docs.alpindale.dev/local-installation-(gpu)/oobabooga/) - 
-[!button text="TavernAI"](https://docs.alpindale.dev/local-installation-(gpu)/tavern/)
+[!button text="KoboldAI"](https://docs.pygmalion.chat/local-installation-(gpu)/kobold) - 
+[!button text="Text-Gen-WebUI"](https://docs.pygmalion.chat/local-installation-(gpu)/oobabooga/) - 
+[!button text="TavernAI"](https://docs.pygmalion.chat/local-installation-(gpu)/tavern/)
 
 ### I'm using Google Colab, how much time do I have to use their GPUs?
 The amount of time you can use when using the free plan for Google Colab highly depends on the traffic Colab recieves and your usage patterns.

--- a/src/Local Installation (CPU)/pygcpp.md
+++ b/src/Local Installation (CPU)/pygcpp.md
@@ -16,12 +16,12 @@ If the model above doesn't work for any reason, you can download the old one ins
 
 ## 7B model
 
-You will need to obtain [your copy](https://docs.alpindale.dev/pygmalion-7b/#merging-the-weights) of Pygmalion 7B by merging the original LLaMA (converted to HF format) with the XORed files in the [PygmalionAI/pygmalion-7b](https://huggingface.co/PygmalionAI/pygmalion-7b) repo. You will then have to convert the model to GGML format, and then quantize it down to 4bit/5bit. 
+You will need to obtain [your copy](https://docs.pygmalion.chat/pygmalion-7b/#merging-the-weights) of Pygmalion 7B by merging the original LLaMA (converted to HF format) with the XORed files in the [PygmalionAI/pygmalion-7b](https://huggingface.co/PygmalionAI/pygmalion-7b) repo. You will then have to convert the model to GGML format, and then quantize it down to 4bit/5bit. 
 
 ### Linux
 
 #### Requirements
-- [`git`](https://docs.alpindale.dev/tools/git)
+- [`git`](https://docs.pygmalion.chat/tools/git)
 - `python`
 #### Converstion
 1. Obtain the merged weights.
@@ -173,8 +173,8 @@ Now open [http://localhost:5001](http://localhost:5001) on your browser.
 ***
 ## Connecting to Tavern
 
-You can connect Pygmalion C++ to Tavern the same way you would the regular KoboldAI. There's a guide included [here](https://docs.alpindale.dev/pygmalion-extras/sillytavern/).
+You can connect Pygmalion C++ to Tavern the same way you would the regular KoboldAI. There's a guide included [here](https://docs.pygmalion.chat/pygmalion-extras/sillytavern/).
 
 ## Connecting to Agnaistic
 
-You can connect Pygmalion C++ to Agnaistic the same way you would the regular KoboldAI. There's a guide included [here](https://docs.alpindale.dev/pygmalion-extras/agnaistic/).
+You can connect Pygmalion C++ to Agnaistic the same way you would the regular KoboldAI. There's a guide included [here](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/).

--- a/src/Local Installation (GPU)/KoboldAI4bit.md
+++ b/src/Local Installation (GPU)/KoboldAI4bit.md
@@ -16,8 +16,8 @@ Use the Table of Contents to navigate.
 
 Please make sure you :
 
-- Have read the [Overview](https://docs.alpindale.dev/local-installation-(gpu)/overview/#overview) and Setting up your GPU pages first. 
-- Have Git installed, tutorial [here](https://docs.alpindale.dev/tools/git/#whats-git-and-do-i-need-it).
+- Have read the [Overview](https://docs.pygmalion.chat/local-installation-(gpu)/overview/#overview) and Setting up your GPU pages first. 
+- Have Git installed, tutorial [here](https://docs.pygmalion.chat/tools/git/#whats-git-and-do-i-need-it).
 - Don't have a `B:` Drive (Windows only)
 
 
@@ -60,7 +60,7 @@ First you want to clone the Kobold-4bit repository:
 git clone https://github.com/0cc4m/KoboldAI -b latestgptq --recurse-submodules
 ``` 
 !!!warning
-Make sure you've read the [git installation guide](https://docs.alpindale.dev/tools/git/).
+Make sure you've read the [git installation guide](https://docs.pygmalion.chat/tools/git/).
 !!!
 
 It shouldn't take more than a few seconds to clone it.
@@ -114,7 +114,7 @@ In your Kobold folder, navigate to the `models` folder.
 
 ![](/static/KoboldAI-4bit-8.PNG)
 
-Right click on the models folder and select "Open in Terminal". You may download a model now using [git](https://docs.alpindale.dev/tools/git) clone commands.
+Right click on the models folder and select "Open in Terminal". You may download a model now using [git](https://docs.pygmalion.chat/tools/git) clone commands.
 There are two models to choose from. If you run
 ```bash
 git lfs clone https://huggingface.co/OccamRazor/pygmalion-6b-gptq-4bit
@@ -154,7 +154,7 @@ Pick the model we just downloaded, then click on load !
 ![](/static/4Bit-Load.PNG)
 
 !!!success
-The model will now be loaded and be ready to be use, if you want to use it with SillyTavern or Agnaistic, please go [here](https://docs.alpindale.dev/pygmalion-extras/sillytavern/#connect-sillytavern),  or the [Agnaistic Guide](https://docs.alpindale.dev/pygmalion-extras/agnaistic/) here.
+The model will now be loaded and be ready to be use, if you want to use it with SillyTavern or Agnaistic, please go [here](https://docs.pygmalion.chat/pygmalion-extras/sillytavern/#connect-sillytavern),  or the [Agnaistic Guide](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/) here.
 !!!
 
 
@@ -186,7 +186,7 @@ chmod +x install_requirements.sh \
 This is a 2.5GB download.
 !!!
 
-3. Navigate to your Kobold folder and right click on the models folder. Choose Actions -> Open Terminal Here. As the steps for downloading a model are the same for Windows, you may refer to this part of the guide: [Downloading the model](https://docs.alpindale.dev/local-installation-(gpu)/koboldai4bit/#downloading-the-model).
+3. Navigate to your Kobold folder and right click on the models folder. Choose Actions -> Open Terminal Here. As the steps for downloading a model are the same for Windows, you may refer to this part of the guide: [Downloading the model](https://docs.pygmalion.chat/local-installation-(gpu)/koboldai4bit/#downloading-the-model).
 
 !!!danger Rename the model file!
 The model needs to be named either `4bit.pt`/`4bit.safetensors` or `4bit-128g.pt`/`4bit-128g.safetensors` to work. Make sure you properly rename it. 

--- a/src/Local Installation (GPU)/oobabooga.md
+++ b/src/Local Installation (GPU)/oobabooga.md
@@ -6,13 +6,13 @@ title: TextGen WebUI
 
 Oobabooga's Text Generation WebUI is a gradio frontend for running large language models. 
 
-Unlike KoboldAI, it can be used as a standalone front-end - you can still connect to SillyTavern or Agnaistic though.
+Unlike KoboldAI, it can be used as a standalone front-end. However, you can still connect to SillyTavern or Agnaistic if you wish.
 
 ![](/static/ooba-cloud1.PNG)
 
 
 ## Automatic Installation
-Please make sure you've read the [Overview](https://docs.alpindale.dev/local-installation-(gpu)/overview/) and [Setting up your GPU](https://docs.alpindale.dev/local-installation-(gpu)/gpu/) pages first. 
+Please make sure you've read the [Overview](https://docs.pygmalion.chat/local-installation-(gpu)/overview/) and [Setting up your GPU](https://docs.pygmalion.chat/local-installation-(gpu)/gpu/) pages first. 
 
 ### Windows
 
@@ -22,7 +22,7 @@ Oobabooga has generously created a one-click installation script for Text-Gen We
 
 Simply extract the `oobabooga-windows.zip` file and click on the`start_windows.bat` file. This will install everything you need.
 
-For GPUs with low VRAM, you will need to use either 8bit or 4bit mode. For 4bit, refer to [KoboldAI 4bit](https://docs.alpindale.dev/local-installation-(gpu)/koboldai4bit/) guide to obtain the model. Place the model inside oobabooga's `models` folder, and rename the large file inside your model folder to `4bit-128g.safetensors` (this will vary between different quantization techniques).
+For GPUs with low VRAM, you will need to use either 8bit or 4bit mode. For 4bit, refer to [KoboldAI 4bit](https://docs.pygmalion.chat/local-installation-(gpu)/koboldai4bit/) guide to obtain the model. Place the model inside oobabooga's `models` folder, and rename the large file inside your model folder to `4bit-128g.safetensors` (this will vary between different quantization techniques).
 
 To enable **8-bit mode**, open the `webui.py` file with a text editor (notepad will work fine), and search for: `# put your flags here!`. The line will look like this:
 ```py
@@ -45,7 +45,7 @@ def run_model():
 ```
 > Change the `groupsize` value and the `--model_type` according to the model you're loading.
 
-If you want to, you can connect Oobabooga to [SillyTavern](https://docs.alpindale.dev/pygmalion-extras/sillytavern/) or the [Agnaistic Guide](https://docs.alpindale.dev/pygmalion-extras/agnaistic/) included here  or the [Agnaistic Guide](https://docs.alpindale.dev/pygmalion-extras/agnaistic/) included here.
+If you want to, you can connect Oobabooga to [SillyTavern](https://docs.pygmalion.chat/pygmalion-extras/sillytavern/) or the [Agnaistic Guide](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/) included here  or the [Agnaistic Guide](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/) included here.
 
 
 ### Linux
@@ -54,7 +54,7 @@ Oobabooga has created a one-click installer for Linux as well. Simply download t
 
 [!file Text-Gen WebUI Linux Installer](https://github.com/oobabooga/one-click-installers/archive/refs/heads/oobabooga-linux.zip)
 
-If you want to, you can connect Oobabooga to [SillyTavern](https://docs.alpindale.dev/pygmalion-extras/sillytavern/) or [Agnaistic](https://docs.alpindale.dev/pygmalion-extras/agnaistic/).
+If you want to, you can connect Oobabooga to [SillyTavern](https://docs.pygmalion.chat/pygmalion-extras/sillytavern/) or [Agnaistic](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/).
 
 ## Manual Installation
 You can also manually install the WebUI. This method is recommended because it's more fun. The following guide is applicable to both Windows and Linux, though the primary audience is Linux users.
@@ -106,4 +106,4 @@ Please don't forget to pass the `--load-in-8bit` argument too if you have a low 
 
 You can view the full list of commands [here](https://github.com/oobabooga/text-generation-webui#starting-the-web-ui){target="_blank"}.
 
-If you want to, you can connect Oobabooga to [SillyTavern](https://docs.alpindale.dev/pygmalion-extras/sillytavern/) or [Agnaistic](https://docs.alpindale.dev/pygmalion-extras/agnaistic/).
+If you want to, you can connect Oobabooga to [SillyTavern](https://docs.pygmalion.chat/pygmalion-extras/sillytavern/) or [Agnaistic](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/).

--- a/src/Local Installation (GPU)/overview.md
+++ b/src/Local Installation (GPU)/overview.md
@@ -4,6 +4,6 @@ icon: telescope
 title: Overview
 ---
 
-The requirements for the 6B and 7B models can be easily met with either an RTX 3090 or a 4090. However, running at lower precision allows running on GPUs with VRAM as low as 6GB. With [koboldcpp](https://docs.alpindale.dev/local-installation-(cpu)/pygcpp/), you can even run these models entirely on CPU! This section of the docs, however, focus on running the models on GPU, so please proceed **only** if you have at least 6GB of VRAM. The [Quickstart](https://docs.alpindale.dev/quickstart) has guides for finding out your VRAM amount if you're unsure.
+The requirements for the 6B and 7B models can be easily met with either an RTX 3090 or a 4090. However, running at lower precision allows running on GPUs with VRAM as low as 6GB. With [koboldcpp](https://docs.pygmalion.chat/local-installation-(cpu)/pygcpp/), you can even run these models entirely on CPU! This section of the docs, however, focus on running the models on GPU, so please proceed **only** if you have at least 6GB of VRAM. The [Quickstart](https://docs.pygmalion.chat/quickstart) has guides for finding out your VRAM amount if you're unsure.
 
 

--- a/src/Pygmalion Extras/Agnaistic.md
+++ b/src/Pygmalion Extras/Agnaistic.md
@@ -6,13 +6,13 @@ title: Agnaistic
 Agnaistic is a user interface you can install on your computer (or use the [production version](https://agnai.chat)) that allows you to interact with text generation AIs and chat/roleplay with the characters you or the community create. Agnaistic is forked from the official Pygmalion website UI, [Galatea UI](https://github.com/PygmalionAI/galatea-ui).
 
 !!!info
-Agnaistic is just a UI; you will need to connect it to a backend: [KoboldAI](https://docs.alpindale.dev/local-installation-(gpu)/kobold/) or [TextGen WebUI](https://docs.alpindale.dev/local-installation-(gpu)/oobabooga/).
+Agnaistic is just a UI; you will need to connect it to a backend: [KoboldAI](https://docs.pygmalion.chat/local-installation-(gpu)/kobold/) or [TextGen WebUI](https://docs.pygmalion.chat/local-installation-(gpu)/oobabooga/).
 !!!
 
 ![](../static/Agnaistic.png)
 
-- [Usage](https://docs.alpindale.dev/pygmalion-extras/agnaistic/#usage)
-- [Installation](https://docs.alpindale.dev/pygmalion-extras/agnaistic/#installation)
+- [Usage](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/#usage)
+- [Installation](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/#installation)
 
 # Usage
 
@@ -32,7 +32,7 @@ On the left side of your screen (or upon clicking the burger menu if on mobile/l
 - Memory
   - List of all memory books you have downloaded. You can edit, download, and delete them here.
 - Invites
-  - If another Agnaistic user has invited you to a [group chat](https://docs.alpindale.dev/pygmalion-extras/agnaistic/#group-chat) this is where the invite will appear.
+  - If another Agnaistic user has invited you to a [group chat](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/#group-chat) this is where the invite will appear.
 - Settings
   - Where you can change various settings about adapters, how the UI looks, how images are generated, and various settings about STT/TTS.
 - Presets
@@ -49,10 +49,10 @@ On the left side of your screen (or upon clicking the burger menu if on mobile/l
 Adapters/Services are synonymous with the term "backend" in these pygmalion docs, Agnaistic supports 
 - Horde
 - Novel AI
-- [KoboldAI](https://docs.alpindale.dev/local-installation-(gpu)/kobold/)
+- [KoboldAI](https://docs.pygmalion.chat/local-installation-(gpu)/kobold/)
 - OpenAI, 
 - Scale
-- [TextGen WebUI](https://docs.alpindale.dev/local-installation-(gpu)/oobabooga/)
+- [TextGen WebUI](https://docs.pygmalion.chat/local-installation-(gpu)/oobabooga/)
 - Claude
 - Goose ai
 
@@ -80,9 +80,9 @@ If you click the context menu you can turn on auto reply for a character. Only o
 
 # Installation
 Self hosting Agnaistic is simple. You have a couple of options:
-- [NPM](https://docs.alpindale.dev/pygmalion-extras/agnaistic/#npm-installation)
-- [Docker](https://docs.alpindale.dev/pygmalion-extras/agnaistic/#docker-installation)
-- [Manually](https://docs.alpindale.dev/pygmalion-extras/agnaistic/#manual-installation)
+- [NPM](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/#npm-installation)
+- [Docker](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/#docker-installation)
+- [Manually](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/#manual-installation)
 
 ### NPM Installation
 

--- a/src/Pygmalion Extras/LoRA.md
+++ b/src/Pygmalion Extras/LoRA.md
@@ -79,7 +79,7 @@ Then you can launch Oobabooga normally and then select the LoRA from the "Parame
 
 ### KoboldAI
 
-To use a LoRA with KoboldAI, you will need to merge the LoRA with the base model first. First, grab the LoRA you want from the [Discord Server](https://discord.com/invite/pygmalionai). You can use [`git lfs`](https://docs.alpindale.dev/tools/git) to download the LoRA. Place the downloaded LoRA (if you're on Windows, the default download path is `C:\Users\username\`) inside KoboldAI's `models` folder. 
+To use a LoRA with KoboldAI, you will need to merge the LoRA with the base model first. First, grab the LoRA you want from the [Discord Server](https://discord.com/invite/pygmalionai). You can use [`git lfs`](https://docs.pygmalion.chat/tools/git) to download the LoRA. Place the downloaded LoRA (if you're on Windows, the default download path is `C:\Users\username\`) inside KoboldAI's `models` folder. 
 
 Then grab the merge script from [here](https://github.com/AlpinDale/lora-merge/blob/main/merge.py) and place it in the `models` folder of your KoboldAI directory.
 
@@ -93,7 +93,7 @@ Now, you can load the new model from the `pygmalion-7b-alpaca-lora` folder, or w
 
 ### koboldcpp
 
-Using LoRAs with [koboldcpp](https://docs.alpindale.dev/local-installation-(cpu)/pygcpp/) requires converting the LoRA to the ggml format first. To do this, grab the LoRA you want from the [Discord Server](https://discord.com/invite/pygmalionai). You can use [`git lfs`](https://docs.alpindale.dev/tools/git) to download the LoRA.
+Using LoRAs with [koboldcpp](https://docs.pygmalion.chat/local-installation-(cpu)/pygcpp/) requires converting the LoRA to the ggml format first. To do this, grab the LoRA you want from the [Discord Server](https://discord.com/invite/pygmalionai). You can use [`git lfs`](https://docs.pygmalion.chat/tools/git) to download the LoRA.
 
 Download [the lora-to-ggml script](https://github.com/ggerganov/llama.cpp/blob/master/convert-lora-to-ggml.py) from the llama.cpp repo, and place as the LoRA folder, but not inside it.
 

--- a/src/Pygmalion Extras/SillyTavern.md
+++ b/src/Pygmalion Extras/SillyTavern.md
@@ -6,7 +6,7 @@ title: SillyTavern
 SillyTavern is a user interface you can install on your computer (and Android phones) that allows you to interact with text generation AIs and chat/roleplay with the characters you or the community create.
 
 !!!info
-SillyTavern is just a UI; you will need to connect it to a backend: [KoboldAI](https://docs.alpindale.dev/local-installation-(gpu)/kobold/) or [TextGen WebUI](https://docs.alpindale.dev/local-installation-(gpu)/oobabooga/).
+SillyTavern is just a UI; you will need to connect it to a backend: [KoboldAI](https://docs.pygmalion.chat/local-installation-(gpu)/kobold/) or [TextGen WebUI](https://docs.pygmalion.chat/local-installation-(gpu)/oobabooga/).
 !!!
 
 <!-- ![](/static/SillyTavern.PNG) -->
@@ -20,7 +20,7 @@ SillyTavern is just a UI; you will need to connect it to a backend: [KoboldAI](h
 #### API Menu
 ![API](../static/st-api.png)
 
-This is where you select the API you wish to connect SillyTavern to. The currently supported APIs are: [KoboldAI](https://docs.alpindale.dev/local-installation-(gpu)/kobold/), [Kobold Horde](https://docs.alpindale.dev/cloud-installation/horde/), Oobabooga's [TextGen WebUI](https://docs.alpindale.dev/local-installation-(gpu)/oobabooga/), [NovelAI](https://novelai.net), [OpenAI](https://platform.openai.com), and [Poe](https://poe.com). **Pygmalion is only accessible through KoboldAI, Kobold Horde, and Oobabooga.** Instructions for acquring the API Key for those two are provided in their respective pages - SillyTavern itself offers guides for acquiring your API key for the other three.
+This is where you select the API you wish to connect SillyTavern to. The currently supported APIs are: [KoboldAI](https://docs.pygmalion.chat/local-installation-(gpu)/kobold/), [Kobold Horde](https://docs.pygmalion.chat/cloud-installation/horde/), Oobabooga's [TextGen WebUI](https://docs.pygmalion.chat/local-installation-(gpu)/oobabooga/), [NovelAI](https://novelai.net), [OpenAI](https://platform.openai.com), and [Poe](https://poe.com). **Pygmalion is only accessible through KoboldAI, Kobold Horde, and Oobabooga.** Instructions for acquring the API Key for those two are provided in their respective pages - SillyTavern itself offers guides for acquiring your API key for the other three.
 
 #### Advanced Formatting
 ![Advanced Formatting](../static/st-adv.png)
@@ -30,7 +30,7 @@ This is where you'll find various options for a more intimate control over the m
 #### World Selector
 ![World Info Selector](../static/st-ws.png)
 
-You can load your World Info and Soft Prompt file here. For a more in-depth explanation, refer to our [Soft Prompt](https://docs.alpindale.dev/pygmalion-extras/soft-prompt/) and [World Info](https://docs.alpindale.dev/settingsandparams/#wi-depth-world-info) pages. You can also click on the Question Mark next to each option in ST for a detailed overview.
+You can load your World Info and Soft Prompt file here. For a more in-depth explanation, refer to our [Soft Prompt](https://docs.pygmalion.chat/pygmalion-extras/soft-prompt/) and [World Info](https://docs.pygmalion.chat/settingsandparams/#wi-depth-world-info) pages. You can also click on the Question Mark next to each option in ST for a detailed overview.
 
 #### User Settings
 ![User Settings](../static/st-user.png)
@@ -58,14 +58,14 @@ You can create, upload, and manage your characters here. ST by default comes wit
 #### Presets
 ![Kobold Presets](../static/st-presets.png)
 
-Depending on which API you've selected, you can choose from the multiple presets provided by the ST team. You can also adjust the generation settings here (learn more about those [here](https://docs.alpindale.dev/settingsandparams/)). Keep in mind that all current Pygmalion/Metharme models have a hard-coded context limit of 2048 tokens, so please don't unlock the context size to assign a higher value.
+Depending on which API you've selected, you can choose from the multiple presets provided by the ST team. You can also adjust the generation settings here (learn more about those [here](https://docs.pygmalion.chat/settingsandparams/)). Keep in mind that all current Pygmalion/Metharme models have a hard-coded context limit of 2048 tokens, so please don't unlock the context size to assign a higher value.
 
 ## Installation
 Installing SillyTavern is simple. It supports the following operating systems:
-- [Windows x64](https://docs.alpindale.dev/pygmalion-extras/sillytavern/#windows-installation)
-- [Linux x64](https://docs.alpindale.dev/pygmalion-extras/sillytavern/#linuxmacos-installation)
-- [macOS (Darwin x64)](https://docs.alpindale.dev/pygmalion-extras/sillytavern/#linuxmacos-installation)
-- [Android (aarch64)](https://docs.alpindale.dev/pygmalion-extras/sillytavern/#android-installation)
+- [Windows x64](https://docs.pygmalion.chat/pygmalion-extras/sillytavern/#windows-installation)
+- [Linux x64](https://docs.pygmalion.chat/pygmalion-extras/sillytavern/#linuxmacos-installation)
+- [macOS (Darwin x64)](https://docs.pygmalion.chat/pygmalion-extras/sillytavern/#linuxmacos-installation)
+- [Android (aarch64)](https://docs.pygmalion.chat/pygmalion-extras/sillytavern/#android-installation)
 
 
 ### Windows Installation
@@ -112,7 +112,7 @@ If everything is working, the CMD should look like this and a SillyTavern tab sh
 ![](/static/STcmd.PNG)
 
 !!!warning
-You still have to [connect](https://docs.alpindale.dev/pygmalion-extras/sillytavern/#connect-sillytavern) it to a backend API!
+You still have to [connect](https://docs.pygmalion.chat/pygmalion-extras/sillytavern/#connect-sillytavern) it to a backend API!
 !!!
 
 
@@ -206,7 +206,7 @@ You can run SillyTavern again by simply opening Termux and entering the command 
 ![](/static/STconnect.PNG)
 
 !!!info The API URL
-If you're running KoboldAI locally, all you need to paste in there is `http://localhost:5000/api`. If you're using Google Colab, copy your [remote URL](https://docs.alpindale.dev/cloud-installation/koboldai/#using-the-remote-url-to-connect-sillytavern) instead. If it ends with a `#` or `new_ui`, remove them and replace them with `/api`. If they don't, simply adding `/api` will suffice.
+If you're running KoboldAI locally, all you need to paste in there is `http://localhost:5000/api`. If you're using Google Colab, copy your [remote URL](https://docs.pygmalion.chat/cloud-installation/koboldai/#using-the-remote-url-to-connect-sillytavern) instead. If it ends with a `#` or `new_ui`, remove them and replace them with `/api`. If they don't, simply adding `/api` will suffice.
 !!!
 
 

--- a/src/Pygmalion Extras/tavern.md
+++ b/src/Pygmalion Extras/tavern.md
@@ -17,7 +17,7 @@ visibility: hidden
 
 This is the first thing you want to configure when opening TavernAI. Here, you can select which API to use, the model, the generation settings, and your own username.
 
-The currently supported APIs are [KoboldAI](https://docs.alpindale.dev/local-installation-(gpu)/kobold/), [Kobold Horde](https://docs.alpindale.dev/cloud-installation/horde/), [NovelAI](https://novelai.net/), and [OpenAI](https://platform.openai.com/). Pygmalion is only available through KoboldAI and Kobold Horde, so please refer to their respective pages on how to set them up for using with Pygmalion.
+The currently supported APIs are [KoboldAI](https://docs.pygmalion.chat/local-installation-(gpu)/kobold/), [Kobold Horde](https://docs.pygmalion.chat/cloud-installation/horde/), [NovelAI](https://novelai.net/), and [OpenAI](https://platform.openai.com/). Pygmalion is only available through KoboldAI and Kobold Horde, so please refer to their respective pages on how to set them up for using with Pygmalion.
 
 #### Character Menu
 ![Character Selection](../static/tavern3.png)

--- a/src/Tools/git.md
+++ b/src/Tools/git.md
@@ -13,9 +13,9 @@ Git gives you access to useful commands, such as `git clone`. You can use it to 
 Many of our tutorials use Git, so you should consider installing it by following the instructions below.
 !!!
 
-- [Windows x64](https://docs.alpindale.dev/tools/git/#windows)
-- [MacOS (Darwin x64)](https://docs.alpindale.dev/tools/git/#macos)
-- [Linux x64](https://docs.alpindale.dev/tools/git/#linux)
+- [Windows x64](https://docs.pygmalion.chat/tools/git/#windows)
+- [MacOS (Darwin x64)](https://docs.pygmalion.chat/tools/git/#macos)
+- [Linux x64](https://docs.pygmalion.chat/tools/git/#linux)
 
 
 ## Windows

--- a/src/index.md
+++ b/src/index.md
@@ -5,9 +5,9 @@ icon: home
 ![](/static/1500x500.jpeg)
 # What is PygmalionAI?
 
-PygmalionAI is an open-source large language model (**LLM**) based on EleutherAI's [GPT-J 6B](https://huggingface.co/EleutherAI/gpt-j-6b){ target="_blank" } and Meta AI's [LLaMA](https://ai.facebook.com/blog/large-language-model-llama-meta-ai/){ target="_blank" } models.
+PygmalionAI is a community dedicated to creating open-source large language models (**LLM**s) based on EleutherAI's [GPT-J 6B](https://huggingface.co/EleutherAI/gpt-j-6b){ target="_blank" } and Meta's [LLaMA](https://ai.facebook.com/blog/large-language-model-llama-meta-ai/){ target="_blank" } models.
 
-In simple terms, Pygmalion is an AI fine-tuned for chatting and roleplaying purposes. The current actively supported Pygmalion AI model is the 7B variant, based on Meta AI's LLaMA model.
+In simple terms, Pygmalion makes AI fine-tuned for chatting and roleplaying purposes. The current actively supported Pygmalion AI model is the 7B variant, based on Meta AI's LLaMA model.
 
 ## Features
 - **Unrestricted**: No measures have been put in place to restrict the output.

--- a/src/pygmalion-7b.md
+++ b/src/pygmalion-7b.md
@@ -21,7 +21,7 @@ This model is based on Meta's LLaMA 7B and 13B, fine-tuned with the regular Pygm
 This is an experimental model with a new prompt format used during training. It is capable of Chatting, RolePlaying, and Storytelling all at once. The prompting format is entirely different from the Chat Models, so Tavern will likely *not work*. 
 
 !!!warning The exact transformers commit might be incorrect!
-I'm not sure exactly which commit we used for converting the original weights - just make sure your converted hashes match the ones [here](https://docs.alpindale.dev/pygmalion-7b/#file-hashes)
+I'm not sure exactly which commit we used for converting the original weights - just make sure your converted hashes match the ones [here](https://docs.pygmalion.chat/pygmalion-7b/#file-hashes)
 !!!
 
 ## Merging the weights
@@ -53,7 +53,7 @@ python3.10 -m venv xor_venv
 source xor_venv/bin/activate
 ```
 !!!danger The exact transformers commit might be incorrect!
-I'm not sure exactly which commit we used for converting the original weights - just make sure your converted hashes match the ones [here](https://docs.alpindale.dev/pygmalion-7b/#file-hashes). If you find it's incorrect, please submit a PR or an [issue](https://github.com/AlpinDale/pygmalion-docs/issues){target="_blank"} with the correct commit hash.
+I'm not sure exactly which commit we used for converting the original weights - just make sure your converted hashes match the ones [here](https://docs.pygmalion.chat/pygmalion-7b/#file-hashes). If you find it's incorrect, please submit a PR or an [issue](https://github.com/AlpinDale/pygmalion-docs/issues){target="_blank"} with the correct commit hash.
 !!!
 
 3. Clone transformers and switch to the tested version:

--- a/src/quickstart.md
+++ b/src/quickstart.md
@@ -18,25 +18,25 @@ You have a few options for running Pygmalion on your mobile phone, depending on 
 ### iOS (iPhone)
 Your only choice is to use Kobold Horde. You can use the Agnaistic website to get started:
 
-[!button Kobold Horde](https://docs.alpindale.dev/cloud-installation/horde/#agnaistic)
+[!button Kobold Horde](https://docs.pygmalion.chat/cloud-installation/horde/#agnaistic)
 
 !!!warning The Horde can be slow!
 Keep in mind that the Kobold Horde is run by generous donors running Pygmalion on their own PCs and allowing other people to use them. The number of users far exceeds the number of hosts. You're encouraged to also chip in by hosting Pygmalion yourself if you meet the required specifications to run it locally on your PC.
 !!!
 
 ### Android
-Android users have more options than iOS users. You can either run the model locally on your phone, no internet connection required, or use the [Kobold Horde](https://docs.alpindale.dev/cloud-installation/horde) via SillyTavern/Agnaistic. 
+Android users have more options than iOS users. You can either run the model locally on your phone, no internet connection required, or use the [Kobold Horde](https://docs.pygmalion.chat/cloud-installation/horde) via SillyTavern/Agnaistic. 
 
 #### Locally
 To run Pygmalion locally on your phone, you'll need to make sure you have **at least** 8GB of RAM. You can find out the memory size for your phone by looking it up online.
 You can refer to our guide here for instructions on how to set it up:
 
-[!button koboldcpp](https://docs.alpindale.dev/local-installation-(cpu)/pygcpp/#android)
+[!button koboldcpp](https://docs.pygmalion.chat/local-installation-(cpu)/pygcpp/#android)
 
 #### SillyTavern
 You can also run Pygmalion using SillyTavern via Kobold Horde. Simply follow the Android instructions in SillyTavern guide:
 
-[!button SillyTavern](https://docs.alpindale.dev/pygmalion-extras/sillytavern/#android-installation)
+[!button SillyTavern](https://docs.pygmalion.chat/pygmalion-extras/sillytavern/#android-installation)
 
 ## Local (PC)
 
@@ -53,7 +53,7 @@ You might be greeted with a dialogue box if it's the first time launcing `dxdiag
 3. Look for the `Display` tab on the top side of the window. Depending on your PC/Laptop, there might be two Display tabs - aptly named "Display 1" and "Display 2". In that case, click on "Display 2" instead.
 4. Look for the `Display Memory (VRAM) part of the screen.
 ![](/static/quick2.jpg)
-5. Proceed to the [next section](https://docs.alpindale.dev/quickstart/#what-to-do-now)
+5. Proceed to the [next section](https://docs.pygmalion.chat/quickstart/#what-to-do-now)
 !!!danger Are you using an AMD GPU?
 Unfortunately, the framework required to enable compute on AMD GPUs (ROCm) is currently unavailable on Windows. While we wait for AMD to add ROCm support to Windows, you will either have to switch to Linux or use the Cloud/C++ solutions.
 !!!
@@ -67,11 +67,11 @@ lspci -k | grep -A 2 -E "(VGA|3D)"
 If you have a dedicated GPU, you should see something like this; an NVIDIA card with the Kernel drive in use being `nvidia`:
 ![](/static/quick3.png)
 
-In that case, run `nvidia-smi` to view your VRAM amount. Then continue to the [next section](https://docs.alpindale.dev/quickstart/#what-to-do-now). If the kernel driver in use is not `nvidia` or `nvidia-lts`, you will need to install the nvidia drivers for your distro. 
+In that case, run `nvidia-smi` to view your VRAM amount. Then continue to the [next section](https://docs.pygmalion.chat/quickstart/#what-to-do-now). If the kernel driver in use is not `nvidia` or `nvidia-lts`, you will need to install the nvidia drivers for your distro. 
 
 If you don't have a discrete GPU, you would see something like this:
 ![](/static/quick4.png)
-In that case, proceed to [this section](https://docs.alpindale.dev/quickstart/#i-have-no-vram)
+In that case, proceed to [this section](https://docs.pygmalion.chat/quickstart/#i-have-no-vram)
 
 
 
@@ -87,26 +87,26 @@ In this case, your only choice is to either run on the Cloud or use Pygmalion C+
 ##### Cloud
 There are several options for running on the cloud - Google Colab and GPU rental services.
 
-**Google Colab** is free, but there are restrictions for the end user. Namely: daily/weekly usage quotas and a less powerful GPU. If you want to take this route, please refer to either the [TextGen WebUI](https://docs.alpindale.dev/cloud-installation/colab) for running Pygmalion itself or [KoboldAI Notebooks](https://docs.alpindale.dev/cloud-installation/koboldai) for the various Mixed Models. 
+**Google Colab** is free, but there are restrictions for the end user. Namely: daily/weekly usage quotas and a less powerful GPU. If you want to take this route, please refer to either the [TextGen WebUI](https://docs.pygmalion.chat/cloud-installation/colab) for running Pygmalion itself or [KoboldAI Notebooks](https://docs.pygmalion.chat/cloud-installation/koboldai) for the various Mixed Models. 
 
-**GPU Rental services**, such as [vast.ai](https://docs.alpindale.dev/cloud-installation/vast) are another option. They're paid services, but with the added benefits of powerful GPUs, virtually no quotas (since you pay hourly and on-the-go), and next to no restrictions on your usage. The included guide for vast.ai in these docs provide a docker image for KoboldAI which will make running Pygmalion very simple for the average user.
+**GPU Rental services**, such as [vast.ai](https://docs.pygmalion.chat/cloud-installation/vast) are another option. They're paid services, but with the added benefits of powerful GPUs, virtually no quotas (since you pay hourly and on-the-go), and next to no restrictions on your usage. The included guide for vast.ai in these docs provide a docker image for KoboldAI which will make running Pygmalion very simple for the average user.
 
 ##### Pygmalion C++
-If you have a decent CPU, you can run Pygmalion with no GPU required, using the GGML framework for Machine Learning. Please refer to [the guide](https://docs.alpindale.dev/local-installation-(cpu)/pygcpp) for instructions on how to proceed.
+If you have a decent CPU, you can run Pygmalion with no GPU required, using the GGML framework for Machine Learning. Please refer to [the guide](https://docs.pygmalion.chat/local-installation-(cpu)/pygcpp) for instructions on how to proceed.
 
 ### I have less than 4GB!
 In that case, please refer to the section above for Cloud and C++ options.
 
 ### I have 6GB or more but less than 10GB!
 
-Please refer to the [4-bit guide](https://docs.alpindale.dev/local-installation-(gpu)/koboldai4bit). Alternatively, you can also use one of the Cloud options if you find the 4bit model undesirable.
+Please refer to the [4-bit guide](https://docs.pygmalion.chat/local-installation-(gpu)/koboldai4bit). Alternatively, you can also use one of the Cloud options if you find the 4bit model undesirable.
 
 ### I have 10GB or more but less than 16GB!
 
-Please refer to the [TextGen WebUI guide](https://docs.alpindale.dev/local-installation-(gpu)/oobabooga) to run Pygmalion at 8bit precision. Make sure you pass the `--load-in-8bit` argument when launching the WebUI. Alternatively, if you're using Linux, you can also use KoboldAI for 8-bit precision mode. Please refer to the [4-bit guide](https://docs.alpindale.dev/local-installation-(gpu)/koboldai4bit) for instructions.
+Please refer to the [TextGen WebUI guide](https://docs.pygmalion.chat/local-installation-(gpu)/oobabooga) to run Pygmalion at 8bit precision. Make sure you pass the `--load-in-8bit` argument when launching the WebUI. Alternatively, if you're using Linux, you can also use KoboldAI for 8-bit precision mode. Please refer to the [4-bit guide](https://docs.pygmalion.chat/local-installation-(gpu)/koboldai4bit) for instructions.
 
 ### I have 16GB or more!
 
-You have the recommended amount of VRAM for the 6B model. You may pick whatever option you want - all the guides here will work for you. You can get started [here](https://docs.alpindale.dev/local-installation-(gpu)/overview).
+You have the recommended amount of VRAM for the 6B model. You may pick whatever option you want - all the guides here will work for you. You can get started [here](https://docs.pygmalion.chat/local-installation-(gpu)/overview).
 
 

--- a/src/settingsandparams.md
+++ b/src/settingsandparams.md
@@ -4,7 +4,7 @@ icon: gear
 title: Settings and Parameters
 ---
 
-You'll find a list of all settings in [KoboldAI](https://docs.alpindale.dev/pygmalion-docs/local-installation-(gpu)/kobold/), Oobabooga's [Text Generation WebUI](https://docs.alpindale.dev/pygmalion-docs/local-installation-(gpu)/oobabooga/), [SillyTavern](https://docs.alpindale.dev/pygmalion-extras/sillytavern) and [Agnaistic](https://docs.alpindale.dev/pygmalion-extras/agnaistic/). Please use the Table of Contents to navigate through this page.
+You'll find a list of all settings in [KoboldAI](https://docs.pygmalion.chat/pygmalion-docs/local-installation-(gpu)/kobold/), Oobabooga's [Text Generation WebUI](https://docs.pygmalion.chat/pygmalion-docs/local-installation-(gpu)/oobabooga/), [SillyTavern](https://docs.pygmalion.chat/pygmalion-extras/sillytavern) and [Agnaistic](https://docs.pygmalion.chat/pygmalion-extras/agnaistic/). Please use the Table of Contents to navigate through this page.
 
 !!!info Work in Progress
 Currently you'll only find a list of settings in KoboldAI. The other UIs will be added soon but they're more or less the same.


### PR DESCRIPTION
Since we finally moved our docs from `docs.alpindale.dev` to [docs.pygmalion.chat](http://docs.pygmalion.chat), it's best to replace the links immediately so we don't run into the errors. I've also taken the liberty of rewording a few things to sound better.